### PR TITLE
Remove README from deployed content

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,6 @@ jobs:
           python -m pip install -r requirements.txt
       - name: Build the JupyterLite site
         run: |
-          cp README.md content
           jupyter lite build --contents content --output-dir dist
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and all example code is available under a [MIT license](https://opensource.org/l
 
 ## ✨ Try it in your browser ✨
 
-➡️ **https://github-pages.arc.ucl.ac.uk/swc-jupyter-lite)**
+➡️ **https://github-pages.arc.ucl.ac.uk/swc-jupyter-lite**
 
 ## Requirements
 


### PR DESCRIPTION
Fixes typo in README and prevents it being copied to bundled content in deployment